### PR TITLE
Expose the default auth for calling from custom authentication handers.

### DIFF
--- a/http.methods.server.api.js
+++ b/http.methods.server.api.js
@@ -189,6 +189,9 @@ _methodHTTP.getUserId = function() {
   return null;
 };
 
+// Expose the default auth for calling from custom authentication handlers.
+HTTP.defaultAuth = _methodHTTP.getUserId;
+
 /*
 
 Add default support for options


### PR DESCRIPTION
This lets you write custom handlers like this:

```
function auth() {
  // Authenticate requests made from the web app.
  var userId = HTTP.defaultAuth.call(this);
  if (userId) return userId;

  // Authenticate requests made from another source e.g. an iOS app.
  userId = / * result of some other scheme */

  return userId;
}

HTTP.methods({
  '/api/foo': {
    auth: auth,
    ...
```