### PR TITLE
Update http.methods.server.api.js

### DIFF
--- a/http.methods.server.api.js
+++ b/http.methods.server.api.js
@@ -538,7 +538,7 @@ WebApp.connectHandlers.use(function(req, res, next) {
         // If no streams are waiting
         if (self._streamsWaiting === 0 &&
             (self.statusCode === 200 || self.statusCode === 206) &&
-            self.done) {
+            self.finished) {
           res.end(resultBuffer);
         }
       }


### PR DESCRIPTION
Changing self.done to self.finished as tiffs and svgs suffer from a write before end error