### PR TITLE
avoid answering to crawlers (spiderable fix)

### DIFF
--- a/http.methods.server.api.js
+++ b/http.methods.server.api.js
@@ -413,6 +413,21 @@ var setCordovaHeaders = function(request, response) {
 // Handle the actual connection
 WebApp.connectHandlers.use(function(req, res, next) {
 
+  // Avoid answering to bot/crawler requests (Spiderable fix)
+  var botExpr = [
+    /^facebookexternalhit/i,
+    /^Facebot/,
+    /^linkedinbot/i,
+    /^twitterbot/i,
+    /^slackbot-linkexpanding/i
+  ];
+  if (/\?.*_escaped_fragment_=/.test(req.url) ||
+    _.any(botExpr, function(re) {
+      return re.test(req.headers['user-agent']);
+    })) {
+    return next();
+  }
+
   // Check to se if this is a http method call
   var method = _methodHTTP.getMethod(req._parsedUrl.pathname);
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   git: 'https://github.com/CollectionFS/Meteor-http-methods.git',
   name: 'cfs:http-methods',
-  version: '0.0.32',
+  version: '0.0.33',
   summary: 'Adds HTTP.methods RESTful'
 });
 


### PR DESCRIPTION
As i was working on a revival of the good old (now deprecated)  `spiderable` package https://github.com/nooitaf/meteor-spiderable i realized that this package somehow sucked up or confused the connectionHandler and phantomjs did never finish rendering. Without `cfs:http-methods` the problem disappeared.

This fixed the issue for me instantly :)
I also don't see a reason for `cfs` to react to any bot/crawler requests.
If this could be avoided from within the `spiderable` package, i am all ears :)